### PR TITLE
Add utility script, use popup, all panes

### DIFF
--- a/open-file-nvim.sh
+++ b/open-file-nvim.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "$CURRENT_DIR/scripts/check_fzf_install.sh"
 

--- a/open-file-nvim.sh
+++ b/open-file-nvim.sh
@@ -1,40 +1,19 @@
 #!/usr/bin/env bash
 
-CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CURRENT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 source "$CURRENT_DIR/scripts/check_fzf_install.sh"
-source "$CURRENT_DIR/scripts/sanitize.sh"
-source "$CURRENT_DIR/scripts/awk_pane_files.sh"
 
 check_fzf
 
-buffer_name="tmux_capture_buffer"
+editor_files=$(source "$CURRENT_DIR/utilities/fzf-files.sh" "$1")
 
-if [ $# -eq 0 ]; then
-  # capture content visible in the current pane
-  tmux capture-pane -J -b "$buffer_name"
+if [[ -z "$editor_files" ]]; then
+  echo "No files found or selected through fzf"
 else
-  # capture all history in the current pane
-  tmux capture-pane -J -S - -E - -b "$buffer_name"
-fi
 
-captured_content=$(tmux show-buffer -b "$buffer_name")
-
-captured_files=$(parse_files "$captured_content")
-#only sanitize from matching lines
-files=$(sanitize_pane_output "$captured_files")
-
-if [ -z "$files" ]; then
-  echo "No files found."
-else
-  # remove any empty or whitespace only entries before fzf
   # sed script will match :number:number at the end of a string for
   # supporting opening files at a target row, col location
-  tmux split-window -h -c "#{pane_current_path}" "echo \"$files\" |
-        sed '/^[[:space:]]*$/d' |
-        fzf -m |
-        sed -E 's/([^:]+):([0-9]+):([0-9]+)/-c e \1 \| normal \2G\3\|/g' |
+  tmux split-window -h -c "#{pane_current_path}" "echo \"$editor_files\" | sed -E 's/([^:]+):([0-9]+):([0-9]+)/-c e \1 \| normal \2G\3\|/g' |
     xargs -I {} $EDITOR {}"
 fi
-
-tmux delete-buffer -b "$buffer_name"

--- a/open-file-nvim.tmux
+++ b/open-file-nvim.tmux
@@ -7,13 +7,19 @@ source "$CURRENT_DIR/scripts/check_fzf_install.sh"
 check_fzf
 
 if [ -z "$(tmux show-option -gqv @open-file-nvim-key)" ]; then
-    tmux bind 'o' run-shell "$CURRENT_DIR/open-file-nvim.sh";
+    tmux bind 'o' run-shell "$CURRENT_DIR/open-file-nvim.sh"
 else
-    tmux bind "$(tmux show-option -gqv @open-file-nvim-key)" run-shell "$CURRENT_DIR/open-file-nvim.sh";
+    tmux bind "$(tmux show-option -gqv @open-file-nvim-key)" run-shell "$CURRENT_DIR/open-file-nvim.sh"
 fi
 
 if [ -z "$(tmux show-option -gqv @open-file-nvim-all-key)" ]; then
-    tmux bind 'O' run-shell "$CURRENT_DIR/open-file-nvim.sh --all";
+    tmux bind 'O' run-shell "$CURRENT_DIR/open-file-nvim.sh --selected-pane-history"
 else
-    tmux bind "$(tmux show-option -gqv @open-file-nvim-all-key)" run-shell "$CURRENT_DIR/open-file-nvim.sh --all";
+    tmux bind "$(tmux show-option -gqv @open-file-nvim-all-key)" run-shell "$CURRENT_DIR/open-file-nvim.sh --selected-pane-history"
+fi
+
+if [ -z "$(tmux show-option -gqv @open-file-nvim-all-history-key)" ]; then
+    tmux bind 'A' run-shell "$CURRENT_DIR/open-file-nvim.sh --all-pane-history"
+else
+    tmux bind "$(tmux show-option -gqv @open-file-nvim-all-history-key)" run-shell "$CURRENT_DIR/open-file-nvim.sh --all-pane-history"
 fi

--- a/scripts/awk_pane_files.sh
+++ b/scripts/awk_pane_files.sh
@@ -5,7 +5,7 @@
 # temporarily override locale settings for awk command
 parse_files() {
   files=$(echo "$1" | LC_ALL=C awk '{
-    while (match($0, /[^[:space:]]*\/[[:alnum:]._-]+(\/[[:alnum:]._-]+)*\.[[:alnum:]]+(:[0-9]+:[0-9]+)?/)) {
+    while (match($0, /[^[:space:]"]*\/[[:alnum:]._-]+(\/[[:alnum:]._-]+)*\.[[:alnum:]]+(:[0-9]+:[0-9]+)?/)) {
         path = substr($0, RSTART, RLENGTH)
         if (!seen[path]++) {
             print path

--- a/tests/awk_pane_files.bats
+++ b/tests/awk_pane_files.bats
@@ -20,7 +20,19 @@ source "$BATS_TEST_DIRNAME/../scripts/awk_pane_files.sh"
     [ "$result" = "/home/pete/file.txt" ]
 }
 
+@test "parse_files should return unique files only double prompt newline separated" {
+    result="$(parse_files "❯ echo \"something/somethingelse.txt\"
+    something/somethingelse.txt")"
+    echo "$result"
+    [ "$result" = "something/somethingelse.txt" ]
+}
+
 @test "remove invalid characters" {
     result="$(remove_invalid_characters "(&&here/is-dashes-in-name/a/file.txt)")"
+    [ "$result" = "here/is-dashes-in-name/a/file.txt" ]
+}
+
+@test "remove invalid characters quotes" {
+    result="$(remove_invalid_characters "\"\"(&&here/is-dashes-in-name/a/file.txt)")"
     [ "$result" = "here/is-dashes-in-name/a/file.txt" ]
 }

--- a/utilities/fzf-files.sh
+++ b/utilities/fzf-files.sh
@@ -17,6 +17,7 @@ parse() {
 }
 
 buffer_name="fzf-files-buffer"
+temp_buffer="fzf-files-temp-buffer"
 files=()
 
 if [ "$1" = "--selected-pane-history" ]; then
@@ -30,8 +31,8 @@ elif [ "$1" = "--all-pane-history" ]; then
   while IFS= read -r pane; do
     pane_id=$(echo "$pane" | awk '{print $1}')
 
-    tmux capture-pane -t "$pane_id" -J -S - -E - -b "fzf_files_temp_buffer"
-    pane_output=$(tmux save-buffer -b "fzf_files_temp_buffer" -)
+    tmux capture-pane -t "$pane_id" -J -S - -E - -b "$temp_buffer"
+    pane_output=$(tmux save-buffer -b "$temp_buffer" -)
 
     tmux set-buffer -b "$buffer_name" -a "$pane_output"
   done <<<"$panes"
@@ -43,7 +44,7 @@ else
   files=("$(parse)")
 fi
 
-# TODO: figure out a way to remove this dupliated call
+# TODO: figure out a way to remove this duplicated call
 # calling parse files again to remove duplicates
 unique_files=$(parse_files "${files[@]}")
 

--- a/utilities/fzf-files.sh
+++ b/utilities/fzf-files.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "$CURRENT_DIR/../scripts/check_fzf_install.sh"
+source "$CURRENT_DIR/../scripts/sanitize.sh"
+source "$CURRENT_DIR/../scripts/awk_pane_files.sh"
+
+parse() {
+  captured_content=$(tmux show-buffer -b "$buffer_name")
+
+  captured_files=$(parse_files "$captured_content")
+  #only sanitize from matching lines
+  files=$(sanitize_pane_output "$captured_files")
+
+  echo "$files"
+}
+
+buffer_name="fzf-files-buffer"
+files=()
+
+if [ "$1" = "--selected-pane-history" ]; then
+  # capture all history in the current pane
+  tmux capture-pane -J -S - -E - -b "$buffer_name"
+  files=("$(parse)")
+elif [ "$1" = "--all-pane-history" ]; then
+  # capture each pane history in the current window
+  panes=$(tmux list-panes -F '#{pane_id} #{pane_current_command} #{pane_current_path}')
+
+  while IFS= read -r pane; do
+    pane_id=$(echo "$pane" | awk '{print $1}')
+
+    tmux capture-pane -t "$pane_id" -J -S - -E - -b "fzf_files_temp_buffer"
+    pane_output=$(tmux save-buffer -b "fzf_files_temp_buffer" -)
+
+    tmux set-buffer -b "$buffer_name" -a "$pane_output"
+  done <<<"$panes"
+
+  files+=("$(parse)")
+else
+  # capture content visible in the current pane
+  tmux capture-pane -J -b "$buffer_name"
+  files=("$(parse)")
+fi
+
+# TODO: figure out a way to remove this dupliated call
+# calling parse files again to remove duplicates
+unique_files=$(parse_files "${files[@]}")
+
+if [ -z "$unique_files" ]; then
+  echo ""
+else
+  tmpfile=$(mktemp)
+
+  tmux display-popup -E "echo \"$unique_files\" | sed '/^[[:space:]]*$/d' | fzf -m > $tmpfile"
+
+  selected_files=$(cat "$tmpfile")
+  rm "$tmpfile"
+
+  echo "$selected_files"
+fi


### PR DESCRIPTION
Add utility script to fzf files to allow users to use this utility in a more customized manner.
Utilize tmux popup to interact with fzf instead of the current pane
Add binding for searching all pane history in the current tmux window

